### PR TITLE
Restructure project directory and packaging

### DIFF
--- a/cmd/cat_file_cmd.go
+++ b/cmd/cat_file_cmd.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"bufio"
@@ -10,7 +10,7 @@ import (
 	"path"
 )
 
-func setupCatFileCmd() (*flag.FlagSet, *bool) {
+func SetupCatFileCmd() (*flag.FlagSet, *bool) {
 	catFileCmd := flag.NewFlagSet("cat-file", flag.ExitOnError)
 
 	var pprint bool
@@ -19,7 +19,7 @@ func setupCatFileCmd() (*flag.FlagSet, *bool) {
 	return catFileCmd, &pprint
 }
 
-func catFileCmdHandler(pprint *bool, file string) {
+func CatFileCmdHandler(pprint *bool, file string) {
 	if !*pprint {
 		log.Fatalf("Missing flag: `-p`\nThis flag is needed to print contents of <file>.")
 	}

--- a/cmd/hash_object_cmd.go
+++ b/cmd/hash_object_cmd.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"compress/zlib"
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-func setupHashObjectCmd() (*flag.FlagSet, *bool, *string) {
+func SetupHashObjectCmd() (*flag.FlagSet, *bool, *string) {
 	hashObjCmd := flag.NewFlagSet("hash-object", flag.ExitOnError)
 
 	var write bool
@@ -27,7 +27,7 @@ func setupHashObjectCmd() (*flag.FlagSet, *bool, *string) {
 }
 
 // TODO: Add functionality for handling non-blob types
-func hashObjectCmdHandler(write *bool, objType *string, file string) {
+func HashObjectCmdHandler(write *bool, objType *string, file string) {
 	f, err := os.Open(file)
 	if err != nil {
 		log.Fatalf("Could not open file: %s\n", err)

--- a/cmd/init_cmd.go
+++ b/cmd/init_cmd.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"flag"
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-func setupInitCommand() (*flag.FlagSet, *bool) {
+func SetupInitCommand() (*flag.FlagSet, *bool) {
 	initCmd := flag.NewFlagSet("init", flag.ExitOnError)
 
 	var quiet bool
@@ -19,7 +19,7 @@ func setupInitCommand() (*flag.FlagSet, *bool) {
 	return initCmd, &quiet
 }
 
-func initCmdHandler(quiet *bool) {
+func InitCmdHandler(quiet *bool) {
 	for _, dir := range []string{".git", ".git/objects", ".git/refs"} {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			log.Printf("Error creating directory: %s\n", err)

--- a/cmd/ls_tree_cmd.go
+++ b/cmd/ls_tree_cmd.go
@@ -1,0 +1,1 @@
+package cmd

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+
+	"github.com/tsoud/GoTGit.git/cmd"
 )
 
 func main() {
@@ -13,12 +15,12 @@ func main() {
 
 	switch command := os.Args[1]; command {
 	case "init":
-		initCmdArgs, quiet := setupInitCommand()
+		initCmdArgs, quiet := cmd.SetupInitCommand()
 		initCmdArgs.Parse(os.Args[2:])
-		initCmdHandler(quiet)
+		cmd.InitCmdHandler(quiet)
 
 	case "cat-file":
-		catFileCmdArgs, pprint := setupCatFileCmd()
+		catFileCmdArgs, pprint := cmd.SetupCatFileCmd()
 		catFileCmdArgs.Parse(os.Args[2:])
 		files := catFileCmdArgs.Args()
 		if len(files) < 1 {
@@ -27,10 +29,10 @@ func main() {
 		if len(files) > 1 {
 			log.Printf("More than one file given.\nOnly showing 1st file %s:", files[0])
 		}
-		catFileCmdHandler(pprint, files[0])
+		cmd.CatFileCmdHandler(pprint, files[0])
 
 	case "hash-object":
-		hashObjCmdArgs, write, objType := setupHashObjectCmd()
+		hashObjCmdArgs, write, objType := cmd.SetupHashObjectCmd()
 		hashObjCmdArgs.Parse(os.Args[2:])
 		file := hashObjCmdArgs.Args()
 		if len(file) < 1 {
@@ -39,7 +41,7 @@ func main() {
 		if len(file) > 1 {
 			log.Printf("Found more than one file. Only hashing %s\n", file[0])
 		}
-		hashObjectCmdHandler(write, objType, file[0])
+		cmd.HashObjectCmdHandler(write, objType, file[0])
 
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command %s\n", command)


### PR DESCRIPTION
Create a package `cmd` for all commands and move all command files into the cmd sub-directory.