### PR TITLE
expand cat-file functionality

### DIFF
--- a/cmd/cat_file_cmd.go
+++ b/cmd/cat_file_cmd.go
@@ -1,32 +1,81 @@
 package cmd
 
 import (
+	"errors"
 	"flag"
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/tsoud/GoTGit.git/gitobj"
 )
 
-func SetupCatFileCmd() (*flag.FlagSet, *bool) {
+const usageMsg = "Usage: cat-file (-p | -t | -s) <object>\n"
+
+func validFlags() []string {
+	return []string{"s", "t", "p"}
+}
+
+func SetupCatFileCmd() *flag.FlagSet {
 	catFileCmd := flag.NewFlagSet("cat-file", flag.ExitOnError)
 
 	var pprint bool
-	catFileCmd.BoolVar(&pprint, "p", false, "Pretty-print the contents of <object> based on its type.")
+	catFileCmd.BoolVar(&pprint, "p", false, "Pretty-print the contents of <object>.")
+	var getType bool
+	catFileCmd.BoolVar(&getType, "t", false, "Show object type identified by <object>.")
+	var getSize bool
+	catFileCmd.BoolVar(&getSize, "s", false, "Show the object size identified by <object>.")
 
-	return catFileCmd, &pprint
+	return catFileCmd
 }
 
-func CatFileCmdHandler(pprint *bool, file string) {
-	if !*pprint {
-		log.Fatalf("Missing flag: `-p`\nThis flag is needed to print contents of <file>.")
+func validateFlags(fs *flag.FlagSet) {
+	if fs.NFlag() == 0 {
+		log.Fatalf("Missing required flag: `-p`, `-s`, or `-t`.\n%s", usageMsg)
+	}
+	if fs.NFlag() > 1 {
+		log.Fatalf(
+			"`cat-file` takes only one flag: `-p`, `-s`, or `-t`.\n%s", usageMsg)
+	}
+}
+
+func catFileOption(fs *flag.FlagSet) (string, error) {
+	validateFlags(fs)
+
+	for _, flag := range validFlags() {
+		if fs.Lookup(flag).Value.String() == "true" {
+			return flag, nil
+		}
 	}
 
+	return "", errors.New("invalid option")
+}
+
+func CatFileCmdHandler(file string, fs *flag.FlagSet) {
+	fs.Parse(os.Args[2:])
+
+	infoType, err := catFileOption(fs)
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
+
+	catFile(file, infoType)
+}
+
+func catFile(file, infoType string) {
 	objInfo, err := gitobj.GitObjInfoFromHash(file)
 	if err != nil {
 		log.Fatalf("error reading object %s: %s", file, err)
 	}
 
-	if err := objInfo.PrintContent(); err != nil {
-		log.Fatalf("%s", err)
+	switch infoType {
+	case "t":
+		fmt.Printf("%s\n", objInfo.Type)
+	case "s":
+		fmt.Printf("%d\n", objInfo.Size)
+	case "p":
+		if err := objInfo.PrintContent(); err != nil {
+			log.Fatalf("%s", err)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 		cmd.InitCmdHandler(quiet)
 
 	case "cat-file":
-		catFileCmdArgs, pprint := cmd.SetupCatFileCmd()
+		catFileCmdArgs := cmd.SetupCatFileCmd()
 		catFileCmdArgs.Parse(os.Args[2:])
 		files := catFileCmdArgs.Args()
 		if len(files) < 1 {
@@ -29,7 +29,7 @@ func main() {
 		if len(files) > 1 {
 			log.Printf("More than one file given.\nOnly showing 1st file %s:", files[0])
 		}
-		cmd.CatFileCmdHandler(pprint, files[0])
+		cmd.CatFileCmdHandler(files[0], catFileCmdArgs)
 
 	case "hash-object":
 		hashObjCmdArgs, write, objType := cmd.SetupHashObjectCmd()


### PR DESCRIPTION
Added options to the `cat-file` command for getting the type and size of an object. Restructured the `cat-file` command to use `GitObjInfo`.