### PR TITLE
create write-tree command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 test*.txt
 .gotgit_test/*
+.gotgit/*
+.gotgit*
 notes/*
 scratch/*
 test_directory/*

--- a/cmd/write_tree_cmd.go
+++ b/cmd/write_tree_cmd.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/tsoud/GoTGit.git/gitobj"
+)
+
+func SetupWriteTreeCmd() (*flag.FlagSet, *bool, *string) {
+	writeTreeCmd := flag.NewFlagSet("write-tree", flag.ExitOnError)
+
+	writeTreeCmd.Usage = func() {
+		fmt.Fprintf(os.Stderr, "gotgit write-tree [--ignore][--prefix=<prefix>/]\n\nusage:\n")
+
+		writeTreeCmd.PrintDefaults()
+	}
+
+	var ignore bool
+	writeTreeCmd.BoolVar(&ignore, "ignore", false,
+		"Ignore files or folders with patterns specified in `.gotgitignore`. This file should "+
+			"be located in the root directory where `write-tree` is being called.",
+	)
+	var prefix string
+	writeTreeCmd.StringVar(&prefix, "prefix", "",
+		"Write a tree object for a subdirectory <prefix> in the project.",
+	)
+
+	return writeTreeCmd, &ignore, &prefix
+}
+
+func WriteTreeCmdHandler(ignore *bool, prefix *string, flags *flag.FlagSet) error {
+	rootDir, err := os.Getwd()
+
+	if err != nil {
+		return err
+	}
+
+	ignoreFile := ""
+	if *ignore {
+		ignoreFile = path.Join(rootDir, ".gotgitignore")
+		if _, err := os.Stat(ignoreFile); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("no valid `.gotgitignore` file found in %s", rootDir)
+			} else {
+				return fmt.Errorf("error reading `.gotgitignore`: %s", err)
+			}
+		}
+	}
+
+	if *prefix != "" {
+		rootDir = path.Join(rootDir, *prefix)
+		if _, err := os.Stat(rootDir); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("subdirectory: %s does not exist", rootDir)
+			} else {
+				return fmt.Errorf("error processing %s: %s", rootDir, err)
+			}
+		}
+	}
+
+	treeObj, err := gitobj.WriteTree(rootDir, ignoreFile, true)
+	if err != nil {
+		return fmt.Errorf("error writing tree: %s", err)
+	}
+
+	fmt.Println(treeObj.Hash)
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -56,6 +56,14 @@ func main() {
 
 		cmd.LSTreeCmdHandler(file[0], lsTreeCmdArgs)
 
+	case "write-tree":
+		writeTreeCmdArgs, ignore, prefix := cmd.SetupWriteTreeCmd()
+		writeTreeCmdArgs.Parse(os.Args[2:])
+
+		if err := cmd.WriteTreeCmdHandler(ignore, prefix, writeTreeCmdArgs); err != nil {
+			log.Fatal(err)
+		}
+
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command %s\n", command)
 		os.Exit(1)


### PR DESCRIPTION
Added the `write-tree` command which writes out a tree object from the current project directory. The command supports the following functionality:
- It will skip files or folders based on patterns in a `.gotgitignore` file located in the root of the project directory (similar to using `.gitignore`).
- A tree object can be written for a subdirectory within the project directory using the `--prefix` option.